### PR TITLE
Update new method signature (Laravel 8.7.0)

### DIFF
--- a/src/HasCompositeKey.php
+++ b/src/HasCompositeKey.php
@@ -3,7 +3,6 @@
 namespace Mpociot\HasCompositeKey;
 
 use Exception;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Use this trait if your model has a composite primary key.
@@ -27,11 +26,11 @@ trait HasCompositeKey
     /**
      * Set the keys for a save update query.
      *
-     * @param  Builder $query
-     * @return Builder
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
      * @throws Exception
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         foreach ($this->getKeyName() as $key) {
             if ($this->$key)


### PR DESCRIPTION
In release 8.7.0 Laravel changed the signature of the `setKeysForSaveQuery(...)` method by removing the`Builder` typehint.

Thus when one uses this trait a `Declaration of ... should be compatible with  ...` error.

This PR adjusts this method signature to match Laravel's.

Commit from `laravel/framework` with the change mentioned above:

https://github.com/laravel/framework/commit/77db028225ccd6ec6bc3359f69482f2e4cc95faf